### PR TITLE
Add JS and LinuxX64 targets

### DIFF
--- a/kmp-nativecoroutines-annotations/build.gradle.kts
+++ b/kmp-nativecoroutines-annotations/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 kotlin {
-    jvm()
     macosX64()
     macosArm64()
     iosArm64()
@@ -17,4 +16,10 @@ kotlin {
     tvosArm64()
     tvosX64()
     tvosSimulatorArm64()
+    jvm()
+    js(BOTH) {
+        browser()
+        nodejs()
+    }
+    linuxX64()
 }

--- a/kmp-nativecoroutines-core/build.gradle.kts
+++ b/kmp-nativecoroutines-core/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 kotlin {
-    jvm()
     val macosX64 = macosX64()
     val macosArm64 = macosArm64()
     val iosArm64 = iosArm64()
@@ -17,6 +16,12 @@ kotlin {
     val tvosArm64 = tvosArm64()
     val tvosX64 = tvosX64()
     val tvosSimulatorArm64 = tvosSimulatorArm64()
+    jvm()
+    js(BOTH) {
+        browser()
+        nodejs()
+    }
+    linuxX64()
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/kmp-nativecoroutines-gradle-plugin/src/main/kotlin/com/rickclephas/kmp/nativecoroutines/gradle/KmpNativeCoroutinesPlugin.kt
+++ b/kmp-nativecoroutines-gradle-plugin/src/main/kotlin/com/rickclephas/kmp/nativecoroutines/gradle/KmpNativeCoroutinesPlugin.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 @Suppress("unused")
 class KmpNativeCoroutinesPlugin: KotlinCompilerPluginSupportPlugin {
@@ -21,7 +22,7 @@ class KmpNativeCoroutinesPlugin: KotlinCompilerPluginSupportPlugin {
     }
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean =
-        kotlinCompilation.platformType == KotlinPlatformType.native
+        kotlinCompilation.target.let { it is KotlinNativeTarget && it.konanTarget.family.isAppleFamily }
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val project = kotlinCompilation.target.project


### PR DESCRIPTION
Fixes #15.

[kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines) also supports the `mingwX64` target, but since that one requires a Windows host I won't be adding it unless there is actual demand.