### PR TITLE
Add version to CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ pod 'KMPNativeCoroutinesAsync', '<version>'    # Swift 5.5 Async/Await implement
 pod 'KMPNativeCoroutinesCombine', '<version>'  # Combine implementation
 pod 'KMPNativeCoroutinesRxSwift', '<version>'  # RxSwift implementation
 ```
-The version for CocoaPods should not contain the version suffix.
+**Note:** the version for CocoaPods should not contain the Kotlin version suffix (e.g. `-new-mm` or `-kotlin-1.6.0`).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Or add it in Xcode by going to `File` > `Add Packages...` and providing the URL:
 
 If you use CocoaPods add one or more of the following libraries to your `Podfile`:
 ```ruby
-pod 'KMPNativeCoroutinesAsync'    # Swift 5.5 Async/Await implementation
-pod 'KMPNativeCoroutinesCombine'  # Combine implementation
-pod 'KMPNativeCoroutinesRxSwift'  # RxSwift implementation
+pod 'KMPNativeCoroutinesAsync', '<version>'    # Swift 5.5 Async/Await implementation
+pod 'KMPNativeCoroutinesCombine', '<version>'  # Combine implementation
+pod 'KMPNativeCoroutinesRxSwift', '<version>'  # RxSwift implementation
 ```
+The version for CocoaPods should not contain the version suffix.
 
 ## Usage
 


### PR DESCRIPTION
The readme tells you to ensure you use the same version of the library everywhere but was missing the version requirement from the CocoaPods section.

It also looks like the pod versions don't contain the version suffix. Please correct that change if not but I couldn't find 0.12.1-new-mm.