### PR TITLE
NativeCoroutinesRefined and NativeCoroutinesRefinedState annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,3 +428,28 @@ val ignoredFlowProperty: Flow<Int>
 @NativeCoroutinesIgnore
 suspend fun ignoredSuspendFunction() { }
 ```
+
+### Refining declarations in Swift
+
+If for some reason you would like to further refine your Kotlin declarations in Swift, you can use the
+`NativeCoroutinesRefined` and `NativeCoroutinesRefinedState` annotations.  
+These will tell the plugin to add the [`ShouldRefineInSwift`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.native/-should-refine-in-swift/)
+annotation to the generated properties/function.
+
+> **Note**: this currently requires a module-wide opt-in to `kotlin.experimental.ExperimentalObjCRefinement`.
+
+You could for example refine your `Flow` property to an `AnyPublisher` property:
+```kotlin
+class Clock {
+    @NativeCoroutinesRefined
+    val time: StateFlow<Long>
+}
+```
+
+```swift
+extension Clock {
+    var time: AnyPublisher<KotlinLong, Error> {
+        createPublisher(for: __time)
+    }
+}
+```

--- a/kmp-nativecoroutines-annotations/src/commonMain/kotlin/com/rickclephas/kmp/nativecoroutines/NativeCoroutinesRefined.kt
+++ b/kmp-nativecoroutines-annotations/src/commonMain/kotlin/com/rickclephas/kmp/nativecoroutines/NativeCoroutinesRefined.kt
@@ -1,0 +1,15 @@
+package com.rickclephas.kmp.nativecoroutines
+
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HidesFromObjC
+import kotlin.native.ShouldRefineInSwift
+
+/**
+ * Identifies properties and functions that require a native [ShouldRefineInSwift] coroutines version.
+ */
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@OptIn(ExperimentalObjCRefinement::class)
+@HidesFromObjC
+annotation class NativeCoroutinesRefined

--- a/kmp-nativecoroutines-annotations/src/commonMain/kotlin/com/rickclephas/kmp/nativecoroutines/NativeCoroutinesRefinedState.kt
+++ b/kmp-nativecoroutines-annotations/src/commonMain/kotlin/com/rickclephas/kmp/nativecoroutines/NativeCoroutinesRefinedState.kt
@@ -1,0 +1,15 @@
+package com.rickclephas.kmp.nativecoroutines
+
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HidesFromObjC
+import kotlin.native.ShouldRefineInSwift
+
+/**
+ * Identifies `StateFlow` properties that require a native [ShouldRefineInSwift] state version.
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@OptIn(ExperimentalObjCRefinement::class)
+@HidesFromObjC
+annotation class NativeCoroutinesRefinedState

--- a/kmp-nativecoroutines-ksp/src/main/kotlin/com/rickclephas/kmp/nativecoroutines/ksp/Names.kt
+++ b/kmp-nativecoroutines-ksp/src/main/kotlin/com/rickclephas/kmp/nativecoroutines/ksp/Names.kt
@@ -7,6 +7,8 @@ private const val packageName = "com.rickclephas.kmp.nativecoroutines"
 
 internal const val nativeCoroutinesAnnotationName = "$packageName.NativeCoroutines"
 internal const val nativeCoroutinesStateAnnotationName = "$packageName.NativeCoroutinesState"
+internal const val nativeCoroutinesRefinedAnnotationName = "$packageName.NativeCoroutinesRefined"
+internal const val nativeCoroutinesRefinedStateAnnotationName = "$packageName.NativeCoroutinesRefinedState"
 internal const val nativeCoroutineScopeAnnotationName = "$packageName.NativeCoroutineScope"
 
 internal val nativeSuspendMemberName = MemberName(packageName, "nativeSuspend")
@@ -18,4 +20,5 @@ internal val nativeFlowClassName = ClassName(packageName, "NativeFlow")
 internal val runMemberName = MemberName("kotlin", "run")
 internal val objCNameAnnotationClassName = ClassName("kotlin.native", "ObjCName")
 internal val optInAnnotationClassName = ClassName("kotlin", "OptIn")
+internal val shouldRefineInSwiftAnnotationClassName = ClassName("kotlin.native", "ShouldRefineInSwift")
 internal const val throwsAnnotationName = "kotlin.Throws"

--- a/kmp-nativecoroutines-ksp/src/main/kotlin/com/rickclephas/kmp/nativecoroutines/ksp/NativeCoroutinesFunSpec.kt
+++ b/kmp-nativecoroutines-ksp/src/main/kotlin/com/rickclephas/kmp/nativecoroutines/ksp/NativeCoroutinesFunSpec.kt
@@ -8,7 +8,8 @@ import com.squareup.kotlinpoet.ksp.*
 
 internal fun KSFunctionDeclaration.toNativeCoroutinesFunSpec(
     scopeProperty: CoroutineScopeProvider.ScopeProperty,
-    options: KmpNativeCoroutinesOptions
+    options: KmpNativeCoroutinesOptions,
+    shouldRefine: Boolean
 ): FunSpec? {
     val typeParameterResolver = getTypeParameterResolver()
     val classDeclaration = parentDeclaration as? KSClassDeclaration
@@ -18,8 +19,13 @@ internal fun KSFunctionDeclaration.toNativeCoroutinesFunSpec(
     docString?.trim()?.let(builder::addKdoc)
     builder.addAnnotations(annotations.toAnnotationSpecs(
         objCName = simpleName,
-        ignoredAnnotationNames = setOf(nativeCoroutinesAnnotationName, throwsAnnotationName)
+        ignoredAnnotationNames = setOf(
+            nativeCoroutinesAnnotationName,
+            nativeCoroutinesRefinedAnnotationName,
+            throwsAnnotationName
+        )
     ))
+    if (shouldRefine) builder.addAnnotation(shouldRefineInSwiftAnnotationClassName)
     // TODO: Add context receivers once those are exported to ObjC
     builder.addModifiers(KModifier.PUBLIC)
 

--- a/kmp-nativecoroutines-ksp/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/ksp/NativeCoroutinesFunSpecTests.kt
+++ b/kmp-nativecoroutines-ksp/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/ksp/NativeCoroutinesFunSpecTests.kt
@@ -453,4 +453,23 @@ class NativeCoroutinesFunSpecTests: CompilationTests() {
         public fun <T> GenericClass<T>.returnGenericSuspendValueNative(): NativeSuspend<T> =
             nativeSuspend(null) { returnGenericSuspendValue() }
     """.trimIndent())
+
+    @Test
+    fun refinedFunction() = runKspTest("""
+        import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesRefined
+        
+        @NativeCoroutinesRefined
+        suspend fun returnSuspendValue(): String = TODO()
+    """.trimIndent(), """
+        import com.rickclephas.kmp.nativecoroutines.NativeSuspend
+        import com.rickclephas.kmp.nativecoroutines.nativeSuspend
+        import kotlin.String
+        import kotlin.native.ObjCName
+        import kotlin.native.ShouldRefineInSwift
+        
+        @ObjCName(name = "returnSuspendValue")
+        @ShouldRefineInSwift
+        public fun returnSuspendValueNative(): NativeSuspend<String> = nativeSuspend(null) {
+            returnSuspendValue() }
+    """.trimIndent())
 }

--- a/kmp-nativecoroutines-ksp/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/ksp/NativeCoroutinesPropertySpecsTests.kt
+++ b/kmp-nativecoroutines-ksp/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/ksp/NativeCoroutinesPropertySpecsTests.kt
@@ -841,4 +841,48 @@ class NativeCoroutinesPropertySpecsTests: CompilationTests() {
         public val flowNative: NativeFlow<String>
           get() = flow.asNativeFlow(null)
     """.trimIndent())
+
+    @Test
+    fun refinedProperty() = runKspTest("""
+        import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesRefined
+        import kotlinx.coroutines.flow.Flow
+        
+        @NativeCoroutinesRefined
+        val flow: Flow<String> get() = TODO()
+    """.trimIndent(), """
+        import com.rickclephas.kmp.nativecoroutines.NativeFlow
+        import com.rickclephas.kmp.nativecoroutines.asNativeFlow
+        import kotlin.String
+        import kotlin.native.ObjCName
+        import kotlin.native.ShouldRefineInSwift
+        
+        @ObjCName(name = "flow")
+        @ShouldRefineInSwift
+        public val flowNative: NativeFlow<String>
+          get() = flow.asNativeFlow(null)
+    """.trimIndent())
+
+    @Test
+    fun refinedStateProperty() = runKspTest("""
+        import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesRefinedState
+        import kotlinx.coroutines.flow.StateFlow
+        
+        @NativeCoroutinesRefinedState
+        val globalState: StateFlow<String> get() = TODO()
+    """.trimIndent(), """
+        import com.rickclephas.kmp.nativecoroutines.NativeFlow
+        import com.rickclephas.kmp.nativecoroutines.asNativeFlow
+        import kotlin.String
+        import kotlin.native.ObjCName
+        import kotlin.native.ShouldRefineInSwift
+        
+        @ShouldRefineInSwift
+        public val globalStateFlow: NativeFlow<String>
+          get() = globalState.asNativeFlow(null)
+        
+        @ObjCName(name = "globalState")
+        @ShouldRefineInSwift
+        public val globalStateValue: String
+          get() = globalState.value
+    """.trimIndent())
 }


### PR DESCRIPTION
You could for example refine your `Flow` property to an `AnyPublisher` property:
```kotlin
class Clock {
    @NativeCoroutinesRefined
    val time: StateFlow<Long>
}
```

```swift
extension Clock {
    var time: AnyPublisher<KotlinLong, Error> {
        createPublisher(for: __time)
    }
}
```

Fixes #119