### PR TITLE
Add Warning for Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ This library solves both of these limitations 😄.
 
 ## Compatibility
 
-The latest version of the library uses Kotlin version `2.0.0`.  
+The latest version of the library uses Kotlin version `2.0.0`.
+
+> [!WARNING]
+> Using unspported versions will probably lead to silent failures.
+
 Compatibility versions for older and/or preview Kotlin versions are also available:
 
 | Version        | Version suffix       |    Kotlin    |    KSP     | Coroutines |


### PR DESCRIPTION
After spending 4 hrs trying to figure out why the example wasn't working it turned out to be because I didn't explicitly specify a KSP version. Added a warning so ppl double check the versions when stuff breaks.

Excited to use this library, it's a missing piece in kotlin multiplatform massively increasing my leverage.