### PR TITLE
Track Kotlin 2.1.20-Beta2 API changes

### DIFF
--- a/kmp-nativecoroutines-compiler/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/compiler/runners/AbstractBaseDiagnosticsTest.kt
+++ b/kmp-nativecoroutines-compiler/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/compiler/runners/AbstractBaseDiagnosticsTest.kt
@@ -29,7 +29,7 @@ abstract class AbstractBaseDiagnosticsTest<R : ResultingArtifact.FrontendOutput<
     abstract val frontend: Constructor<FrontendFacade<R>>
     abstract fun TestConfigurationBuilder.handlersSetup()
 
-    final override fun TestConfigurationBuilder.configuration() {
+    override fun configure(builder: TestConfigurationBuilder) = with(builder) {
         globalDefaults {
             frontend = targetFrontend
             targetPlatform = NativePlatforms.unspecifiedNativePlatform

--- a/kmp-nativecoroutines-compiler/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/compiler/runners/AbstractFirBaseCodegenTest.kt
+++ b/kmp-nativecoroutines-compiler/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/compiler/runners/AbstractFirBaseCodegenTest.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.test.backend.ir.JvmIrBackendFacade
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.builders.configureFirHandlersStep
 import org.jetbrains.kotlin.test.builders.configureIrHandlersStep
+import org.jetbrains.kotlin.test.configuration.configureDumpHandlersForCodegenTest
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.DUMP_IR
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.DUMP_KT_IR
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.IGNORE_DEXING
@@ -34,7 +35,6 @@ import org.jetbrains.kotlin.test.frontend.fir.handlers.FirScopeDumpHandler
 import org.jetbrains.kotlin.test.initIdeaConfiguration
 import org.jetbrains.kotlin.test.model.*
 import org.jetbrains.kotlin.test.runners.codegen.AbstractJvmBlackBoxCodegenTestBase
-import org.jetbrains.kotlin.test.runners.codegen.configureDumpHandlersForCodegenTest
 import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
 import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
 import org.junit.jupiter.api.BeforeAll

--- a/kmp-nativecoroutines-compiler/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/compiler/runners/AbstractFirDiagnosticsTest.kt
+++ b/kmp-nativecoroutines-compiler/src/test/kotlin/com/rickclephas/kmp/nativecoroutines/compiler/runners/AbstractFirDiagnosticsTest.kt
@@ -4,14 +4,14 @@ import org.jetbrains.kotlin.test.Constructor
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.builders.firHandlersStep
+import org.jetbrains.kotlin.test.configuration.configurationForClassicAndFirTestsAlongside
+import org.jetbrains.kotlin.test.configuration.enableLazyResolvePhaseChecking
 import org.jetbrains.kotlin.test.directives.configureFirParser
 import org.jetbrains.kotlin.test.frontend.fir.FirFrontendFacade
 import org.jetbrains.kotlin.test.frontend.fir.FirOutputArtifact
 import org.jetbrains.kotlin.test.frontend.fir.handlers.FirDiagnosticsHandler
 import org.jetbrains.kotlin.test.frontend.fir.handlers.FirResolvedTypesVerifier
 import org.jetbrains.kotlin.test.model.*
-import org.jetbrains.kotlin.test.runners.configurationForClassicAndFirTestsAlongside
-import org.jetbrains.kotlin.test.runners.enableLazyResolvePhaseChecking
 
 abstract class AbstractFirBaseDiagnosticsTest(
     private val parser: FirParser


### PR DESCRIPTION
The overridable `configuration` extension function was removed in JetBrains/kotlin@777d0d9. The utility functions changed package in JetBrains/kotlin@7a9c0e7.

Our team needs to upgrade to Kotlin 2.1.20-Beta2, and unfortunately we are blocked by KMP-NativeCoroutines not tracking the latest Beta. I noticed your PR and wanted to see if I could continue working on it to fix the build issues, but unfortunately I'm not too sure how to fix the remaining CI issues.