### PR TITLE
AsyncThrowingStream instead of custom type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,4 @@ gradle-app.setting
 **/build/
 
 # End of https://www.toptal.com/developers/gitignore/api/swift,xcode,gradle,kotlin,intellij,cocoapods
+.DS_Store

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/KMPNativeCoroutinesAsync/AsyncSequence.swift
+++ b/KMPNativeCoroutinesAsync/AsyncSequence.swift
@@ -10,10 +10,17 @@ import Foundation
 import KMPNativeCoroutinesCore
 
 /// Converts a NativeFlow to an ``AsyncThrowingStream``
+/// - Parameters:
+///   - nativeFlow: the coroutine flow that is translated from kotlin to swift exposes closured. This is a typealias
+///   - bufferingPolicy: The default policy in Kotlin for flows is to consume directly and suspend until another value arrived.
+///   `AsyncThrowingStream` will buffer unbounded  by default if the consumer cannot directly consume the value.
+///   Change it to `.bufferingNewest(1)` if you want to match the Kotlin behaviour
+/// - Returns: An ``AsyncThrowingStream``  that can be consumed wit `for try await in ...`.
 public func asyncSequence<Output, Failure: Error, Unit>(
-  for nativeFlow: @escaping NativeFlow<Output, Failure, Unit>
+  for nativeFlow: @escaping NativeFlow<Output, Failure, Unit>,
+  bufferingPolicy: AsyncThrowingStream<Output, Error>.Continuation.BufferingPolicy = .unbounded
 ) -> AsyncThrowingStream<Output, Error> {
-  AsyncThrowingStream { continuation in
+    AsyncThrowingStream(bufferingPolicy: bufferingPolicy) { continuation in
     let lock = NSRecursiveLock()
     
     let callbacks = FlowCallbacks<Output, Failure, Unit>(

--- a/KMPNativeCoroutinesAsync/AsyncSequence.swift
+++ b/KMPNativeCoroutinesAsync/AsyncSequence.swift
@@ -6,103 +6,70 @@
 //
 
 import Dispatch
+import Foundation
 import KMPNativeCoroutinesCore
 
-/// Wraps the `NativeFlow` in a `NativeFlowAsyncSequence`.
-/// - Parameter nativeFlow: The native flow to collect.
-/// - Returns: A `NativeFlowAsyncSequence` that yields the collected values.
+/// Converts a NativeFlow to an ``AsyncThrowingStream``
 public func asyncSequence<Output, Failure: Error, Unit>(
-    for nativeFlow: @escaping NativeFlow<Output, Failure, Unit>
-) -> NativeFlowAsyncSequence<Output, Error, Unit> {
-    return NativeFlowAsyncSequence(nativeFlow: nativeFlow)
+  for nativeFlow: @escaping NativeFlow<Output, Failure, Unit>
+) -> AsyncThrowingStream<Output, Error> {
+  AsyncThrowingStream { continuation in
+    let lock = NSRecursiveLock()
+    
+    let callbacks = FlowCallbacks<Output, Failure, Unit>(
+      onItem: { item, next, unit in
+        lock.lock()
+        defer { lock.unlock() }
+        guard !Task.isCancelled else {
+          continuation.finish(throwing: CancellationError())
+          return unit
+        }
+        continuation.yield(item)
+        return next()
+      },
+      onComplete: { error, unit in
+        lock.lock()
+        defer { lock.unlock() }
+        guard !Task.isCancelled else {
+          continuation.finish(throwing: CancellationError())
+          return unit
+        }
+        if let error = error {
+          continuation.finish(throwing: error)
+        } else {
+          continuation.finish()
+        }
+        return unit
+      },
+      onCancelled: { error, unit in
+        lock.lock()
+        defer { lock.unlock() }
+        guard !Task.isCancelled else {
+          continuation.finish(throwing: CancellationError())
+          return unit
+        }
+        continuation.finish(throwing: error)
+        return unit
+      }
+    )
+    
+    let cancellable = nativeFlow(
+      callbacks.onItem,
+      callbacks.onComplete,
+      callbacks.onCancelled
+    )
+    
+    continuation.onTermination = { @Sendable _ in
+      lock.lock()
+      defer { lock.unlock() }
+      _ = cancellable()
+    }
+  }
 }
 
-public struct NativeFlowAsyncSequence<Output, Failure: Error, Unit>: AsyncSequence {
-    public typealias Element = Output
-    
-    var nativeFlow: NativeFlow<Output, Failure, Unit>
-    
-    public class Iterator: AsyncIteratorProtocol, @unchecked Sendable {
-        
-        private let semaphore = DispatchSemaphore(value: 1)
-        private var nativeCancellable: NativeCancellable<Unit>?
-        private var item: (Output, () -> Unit)? = nil
-        private var result: Failure?? = Optional.none
-        private var cancellationError: Failure? = nil
-        private var continuation: UnsafeContinuation<Output?, Error>? = nil
-        
-        init(nativeFlow: NativeFlow<Output, Failure, Unit>) {
-            nativeCancellable = nativeFlow({ item, next, unit in
-                self.semaphore.wait()
-                defer { self.semaphore.signal() }
-                if let continuation = self.continuation {
-                    continuation.resume(returning: item)
-                    self.continuation = nil
-                    return next()
-                } else {
-                    self.item = (item, next)
-                    return unit
-                }
-            }, { error, unit in
-                self.semaphore.wait()
-                defer { self.semaphore.signal() }
-                self.result = Optional.some(error)
-                if let continuation = self.continuation {
-                    if let error = error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume(returning: nil)
-                    }
-                    self.continuation = nil
-                }
-                self.nativeCancellable = nil
-                return unit
-            }, { cancellationError, unit in
-                self.semaphore.wait()
-                defer { self.semaphore.signal() }
-                self.cancellationError = cancellationError
-                if let continuation = self.continuation {
-                    continuation.resume(returning: nil)
-                    self.continuation = nil
-                }
-                self.nativeCancellable = nil
-                return unit
-            })
-        }
-        
-        public func next() async throws -> Output? {
-            return try await withTaskCancellationHandler {
-                try await withUnsafeThrowingContinuation { continuation in
-                    self.semaphore.wait()
-                    defer { self.semaphore.signal() }
-                    if let (item, next) = self.item {
-                        continuation.resume(returning: item)
-                        _ = next()
-                        self.item = nil
-                    } else if let result = self.result {
-                        if let error = result {
-                            continuation.resume(throwing: error)
-                        } else {
-                            continuation.resume(returning: nil)
-                        }
-                    } else if self.cancellationError != nil {
-                        continuation.resume(throwing: CancellationError())
-                    } else {
-                        guard self.continuation == nil else {
-                            fatalError("Concurrent calls to next aren't supported")
-                        }
-                        self.continuation = continuation
-                    }
-                }
-            } onCancel: {
-                _ = nativeCancellable?()
-                nativeCancellable = nil
-            }
-        }
-    }
-    
-    public func makeAsyncIterator() -> Iterator {
-        return Iterator(nativeFlow: nativeFlow)
-    }
+/// A struct containing the callbacks for a native Kotlin Flow.
+struct FlowCallbacks<Output, Failure: Error, Unit> {
+  let onItem: NativeCallback2<Output, () -> Unit, Unit>
+  let onComplete: NativeCallback<Failure?, Unit>
+  let onCancelled: NativeCallback<Failure, Unit>
 }
-

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "5dd1907d64f0d36f158f61a466bab75067224893",
+          "version": "6.9.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
I had a look at your super library and it solved many issues compared to Skie. I had some trouble understanding the asyncSequence as I did not understand why [AsyncThrowingStream](https://developer.apple.com/documentation/swift/asyncthrowingstream) could not be used directly. So I tried and came up with this solution that at least to me is simpler. Would you consider merging it?

It removes the need for the custom type `NativeFlowAsyncSequence` in favor or the `AsyncThrowingStream` so this would be breaking. But it keeps the use in a for try await in ... loop so I did not have to alter the tests for them to work.

I added a lock although I think you can debate as the closure of `AsyncThrowingStream` is in Swifts structured concurrency that it is safe to remove it. It does not harm the structured concurrency so I kept it as I do not know if it is needed for the Kotlin part.