### PR TITLE
Remove single value buffer from AsyncSequence implementation

### DIFF
--- a/sample/Async/AsyncSequenceIntegrationTests.swift
+++ b/sample/Async/AsyncSequenceIntegrationTests.swift
@@ -41,8 +41,7 @@ class AsyncSequenceIntegrationTests: XCTestCase {
             var receivedValueCount: Int32 = 0
             for try await _ in sequence {
                 let emittedCount = integrationTests.emittedCount
-                // Note the AsyncSequence buffers at most a single item
-                XCTAssert(emittedCount == receivedValueCount || emittedCount == receivedValueCount + 1, "Back pressure isn't applied")
+                XCTAssert(emittedCount == receivedValueCount, "Back pressure isn't applied")
                 delay(0.2)
                 receivedValueCount += 1
             }


### PR DESCRIPTION
Only the first emitted value needs to be buffered. Once we have consumed the first value we can wait for a call to `Iterator.next` before invoking the `next` callback from Kotlin.
This will make sure that `emit` in Kotlin suspends until Swift calls `Iterator.next` to get the next value.

We could even delay the `Flow` collection until the first call to `Iterator.next`.
Which would allow us to remove the `item` buffer completely.
Although in that case we'll need a `fatalError` for the `nil` check on `continuation`.
