### PR TITLE
[Swift PM] This PR upgrades to Swift 5.9 and fixed multiple issues related to SwiftPM 

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/KMPNativeCoroutinesAsync/AsyncFunction.swift
+++ b/KMPNativeCoroutinesAsync/AsyncFunction.swift
@@ -12,30 +12,22 @@ import KMPNativeCoroutinesCore
 /// - Parameter nativeSuspend: The native suspend function to await.
 /// - Returns: The result from the `nativeSuspend`.
 /// - Throws: Errors thrown by the `nativeSuspend`.
-public func asyncFunction<Result, Failure: Error, Unit>(
+public func asyncFunction<Result: Sendable, Failure: Error & Sendable, Unit: Sendable>(
     for nativeSuspend: @escaping NativeSuspend<Result, Failure, Unit>
 ) async throws -> Result {
     try await AsyncFunctionTask(nativeSuspend: nativeSuspend).awaitResult()
 }
 
-/// This function provides source compatibility during the migration to Swift export.
-///
-/// This is a no-op function and it can be safely removed once you have fully migrated to Swift export.
-@available(*, deprecated, message: "Kotlin Coroutines are supported by Swift export")
-public func asyncFunction<Result>(for result: Result) async -> Result {
-    return result
-}
-
 /// Wraps the `NativeSuspend` in an async function.
 /// - Parameter nativeSuspend: The native suspend function to await.
 /// - Throws: Errors thrown by the `nativeSuspend`.
-public func asyncFunction<Unit, Failure: Error>(
+public func asyncFunction<Unit: Sendable, Failure: Error & Sendable>(
     for nativeSuspend: @escaping NativeSuspend<Unit, Failure, Unit>
 ) async throws -> Void {
     _ = try await AsyncFunctionTask(nativeSuspend: nativeSuspend).awaitResult()
 }
 
-private class AsyncFunctionTask<Result, Failure: Error, Unit>: @unchecked Sendable {
+private class AsyncFunctionTask<Result: Sendable, Failure: Error & Sendable, Unit: Sendable>: @unchecked Sendable {
     
     private let semaphore = DispatchSemaphore(value: 1)
     private var nativeCancellable: NativeCancellable<Unit>?
@@ -45,7 +37,7 @@ private class AsyncFunctionTask<Result, Failure: Error, Unit>: @unchecked Sendab
     private var continuation: UnsafeContinuation<Result, Error>? = nil
     
     init(nativeSuspend: NativeSuspend<Result, Failure, Unit>) {
-        nativeCancellable = nativeSuspend({ result, unit in
+        nativeCancellable = nativeSuspend({ @Sendable (result, unit) in
             self.semaphore.wait()
             defer { self.semaphore.signal() }
             self.result = result
@@ -55,7 +47,7 @@ private class AsyncFunctionTask<Result, Failure: Error, Unit>: @unchecked Sendab
             }
             self.nativeCancellable = nil
             return unit
-        }, { error, unit in
+        }, { @Sendable (error, unit) in
             self.semaphore.wait()
             defer { self.semaphore.signal() }
             self.error = error
@@ -65,7 +57,7 @@ private class AsyncFunctionTask<Result, Failure: Error, Unit>: @unchecked Sendab
             }
             self.nativeCancellable = nil
             return unit
-        }, { cancellationError, unit in
+        }, { @Sendable (cancellationError, unit) in
             self.semaphore.wait()
             defer { self.semaphore.signal() }
             self.cancellationError = cancellationError

--- a/KMPNativeCoroutinesAsync/AsyncSequence.swift
+++ b/KMPNativeCoroutinesAsync/AsyncSequence.swift
@@ -17,6 +17,13 @@ public func asyncSequence<Output, Failure: Error, Unit>(
     return NativeFlowAsyncSequence(nativeFlow: nativeFlow)
 }
 
+/// Simple wrapper to satisfy Swift 6 Sendable checks when values cross concurrency boundaries.
+/// Use only when `Output` is effectively immutable (typical for KMM models).
+public struct UncheckedSendable<T>: @unchecked Sendable {
+    public let value: T
+    public init(_ value: T) { self.value = value }
+}
+
 public struct NativeFlowAsyncSequence<Output, Failure: Error, Unit>: AsyncSequence {
     public typealias Element = Output
     
@@ -26,28 +33,40 @@ public struct NativeFlowAsyncSequence<Output, Failure: Error, Unit>: AsyncSequen
         
         private let semaphore = DispatchSemaphore(value: 1)
         private var nativeCancellable: NativeCancellable<Unit>?
-        private var item: (Output, () -> Unit)? = nil
-        private var result: Failure?? = Optional.none
-        private var cancellationError: Failure? = nil
-        private var continuation: UnsafeContinuation<Output?, Error>? = nil
         
+        // Store the next item + "next" callback. Wrapped to satisfy Swift 6 Sendable checks.
+        private var item: (UncheckedSendable<Output>, () -> Unit)? = nil
+        
+        // Completion result from native flow
+        private var result: Failure?? = Optional.none
+        
+        // Cancellation from native flow
+        private var cancellationError: Failure? = nil
+        
+        // Continuation used to suspend/resume `next()`. Wrapped to satisfy Swift 6 Sendable checks.
+        private var continuation: UnsafeContinuation<UncheckedSendable<Output>?, Error>? = nil
+        
+        @Sendable
         init(nativeFlow: NativeFlow<Output, Failure, Unit>) {
             nativeCancellable = nativeFlow({ [weak self] item, next, unit  in
                 guard let self else { return unit }
                 self.semaphore.wait()
                 defer { self.semaphore.signal() }
+                
                 if let continuation = self.continuation {
-                    continuation.resume(returning: item)
+                    continuation.resume(returning: UncheckedSendable(item))
                     self.continuation = nil
                     return next()
                 } else {
-                    self.item = (item, next)
+                    self.item = (UncheckedSendable(item), next)
                     return unit
                 }
+                
             }, { [weak self] error, unit in
                 guard let self else { return unit }
                 self.semaphore.wait()
                 defer { self.semaphore.signal() }
+                
                 self.result = Optional.some(error)
                 if let continuation = self.continuation {
                     if let error = error {
@@ -59,10 +78,12 @@ public struct NativeFlowAsyncSequence<Output, Failure: Error, Unit>: AsyncSequen
                 }
                 self.nativeCancellable = nil
                 return unit
+                
             }, { [weak self] cancellationError, unit in
                 guard let self else { return unit }
                 self.semaphore.wait()
                 defer { self.semaphore.signal() }
+                
                 self.cancellationError = cancellationError
                 if let continuation = self.continuation {
                     continuation.resume(returning: nil)
@@ -74,22 +95,26 @@ public struct NativeFlowAsyncSequence<Output, Failure: Error, Unit>: AsyncSequen
         }
         
         public func next() async throws -> Output? {
-            return try await withTaskCancellationHandler {
-                try await withUnsafeThrowingContinuation { continuation in
+            let wrapped: UncheckedSendable<Output>? = try await withTaskCancellationHandler {
+                try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<UncheckedSendable<Output>?, Error>) in
                     self.semaphore.wait()
                     defer { self.semaphore.signal() }
+                    
                     if let (item, next) = self.item {
                         continuation.resume(returning: item)
                         _ = next()
                         self.item = nil
+                        
                     } else if let result = self.result {
                         if let error = result {
                             continuation.resume(throwing: error)
                         } else {
                             continuation.resume(returning: nil)
                         }
+                        
                     } else if self.cancellationError != nil {
                         continuation.resume(throwing: CancellationError())
+                        
                     } else {
                         guard self.continuation == nil else {
                             fatalError("Concurrent calls to next aren't supported")
@@ -101,6 +126,8 @@ public struct NativeFlowAsyncSequence<Output, Failure: Error, Unit>: AsyncSequen
                 _ = nativeCancellable?()
                 nativeCancellable = nil
             }
+            
+            return wrapped?.value
         }
         
         deinit {
@@ -113,4 +140,3 @@ public struct NativeFlowAsyncSequence<Output, Failure: Error, Unit>: AsyncSequen
         return Iterator(nativeFlow: nativeFlow)
     }
 }
-

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "132aea4f236ccadc51590b38af0357a331d51fa2",
+          "version": "6.10.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,68 +1,42 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
     name: "KMPNativeCoroutines",
-    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
+    platforms: [.iOS(.v16), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
     products: [
-        .library(
-            name: "KMPNativeCoroutinesCore",
-            targets: ["KMPNativeCoroutinesCore"]
-        ),
-        .library(
-            name: "KMPNativeCoroutinesCombine",
-            targets: ["KMPNativeCoroutinesCombine"]
-        ),
-        .library(
-            name: "KMPNativeCoroutinesAsync",
-            targets: ["KMPNativeCoroutinesAsync"]
-        ),
-        .library(
-            name: "KMPNativeCoroutinesRxSwift",
-            targets: ["KMPNativeCoroutinesRxSwift"]
-        )
+        .library(name: "KMPNativeCoroutinesCore", targets: ["KMPNativeCoroutinesCore"]),
+        .library(name: "KMPNativeCoroutinesCombine", targets: ["KMPNativeCoroutinesCombine"]),
+        .library(name: "KMPNativeCoroutinesAsync", targets: ["KMPNativeCoroutinesAsync"]),
+        .library(name: "KMPNativeCoroutinesRxSwift", targets: ["KMPNativeCoroutinesRxSwift"])
     ],
     dependencies: [
-        .package(
-            url: "https://github.com/ReactiveX/RxSwift.git",
-            from: "6.0.0"
-        )
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.0.0")
     ],
     targets: [
-        .target(
-            name: "KMPNativeCoroutinesCore",
-            path: "KMPNativeCoroutinesCore"
-        ),
-        .target(
-            name: "KMPNativeCoroutinesCombine",
-            dependencies: ["KMPNativeCoroutinesCore"],
-            path: "KMPNativeCoroutinesCombine"
-        ),
-        .testTarget(
-            name: "KMPNativeCoroutinesCombineTests",
-            dependencies: ["KMPNativeCoroutinesCombine"],
-            path: "KMPNativeCoroutinesCombineTests"
-        ),
-        .target(
-            name: "KMPNativeCoroutinesAsync",
-            dependencies: ["KMPNativeCoroutinesCore"],
-            path: "KMPNativeCoroutinesAsync"
-        ),
-        .testTarget(
-            name: "KMPNativeCoroutinesAsyncTests",
-            dependencies: ["KMPNativeCoroutinesAsync"],
-            path: "KMPNativeCoroutinesAsyncTests"
-        ),
-        .target(
-            name: "KMPNativeCoroutinesRxSwift",
-            dependencies: ["KMPNativeCoroutinesCore", "RxSwift"],
-            path: "KMPNativeCoroutinesRxSwift"
-        ),
-        .testTarget(
-            name: "KMPNativeCoroutinesRxSwiftTests",
-            dependencies: ["KMPNativeCoroutinesRxSwift"],
-            path: "KMPNativeCoroutinesRxSwiftTests"
-        )
-    ],
-    swiftLanguageVersions: [.v5]
+        .target(name: "KMPNativeCoroutinesCore", path: "KMPNativeCoroutinesCore"),
+        .target(name: "KMPNativeCoroutinesCombine",
+                dependencies: ["KMPNativeCoroutinesCore"],
+                path: "KMPNativeCoroutinesCombine"),
+        .testTarget(name: "KMPNativeCoroutinesCombineTests",
+                    dependencies: ["KMPNativeCoroutinesCombine"],
+                    path: "KMPNativeCoroutinesCombineTests"),
+        
+            .target(name: "KMPNativeCoroutinesAsync",
+                    dependencies: ["KMPNativeCoroutinesCore"],
+                    path: "KMPNativeCoroutinesAsync"),
+        .testTarget(name: "KMPNativeCoroutinesAsyncTests",
+                    dependencies: ["KMPNativeCoroutinesAsync"],
+                    path: "KMPNativeCoroutinesAsyncTests"),
+        
+            .target(name: "KMPNativeCoroutinesRxSwift",
+                    dependencies: [
+                        "KMPNativeCoroutinesCore",
+                        .product(name: "RxSwift", package: "RxSwift")
+                    ],
+                    path: "KMPNativeCoroutinesRxSwift"),
+        .testTarget(name: "KMPNativeCoroutinesRxSwiftTests",
+                    dependencies: ["KMPNativeCoroutinesRxSwift"],
+                    path: "KMPNativeCoroutinesRxSwiftTests")
+    ]
 )


### PR DESCRIPTION
Unfortunately using latest versions of `KMP-NativeCoroutines` through `SwiftPM` was failing, this `PR` fixes multiple issues  related to SwiftPM, upgrades to Swift `5.9`, drops `.iOS(.v13)` to `.iOS(.v15)`,  and sets the scene for some swift 6.  