### PR TITLE
Adds support for WasmWasi

### DIFF
--- a/kmp-nativecoroutines-annotations/build.gradle.kts
+++ b/kmp-nativecoroutines-annotations/build.gradle.kts
@@ -36,4 +36,8 @@ kotlin {
         nodejs()
         d8()
     }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmWasi {
+        nodejs()
+    }
 }

--- a/kmp-nativecoroutines-core/build.gradle.kts
+++ b/kmp-nativecoroutines-core/build.gradle.kts
@@ -57,6 +57,10 @@ kotlin {
         nodejs()
         d8()
     }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmWasi {
+        nodejs()
+    }
 
     targets.all {
         compilations.all {


### PR DESCRIPTION
Simply adds WasmWasi target to allow kmp project supporting WasmWasi to build. No other changes are required other than adding target support